### PR TITLE
Added codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @obfischer @DirkMahler @StephanPirnbaum
+


### PR DESCRIPTION
Adding a codeowners files allows to specify default
assignees for pull requests and similiar features.